### PR TITLE
Fix Helm chart image to public address

### DIFF
--- a/charts/huaweicloud-webhook/values.yaml
+++ b/charts/huaweicloud-webhook/values.yaml
@@ -14,12 +14,9 @@ certManager:
   serviceAccountName: cert-manager
 
 image:
-  repository: swr.ap-southeast-1.myhuaweicloud.com/chenweikai/cert-manager-webhook-huaweicloud
+  repository: swr.ap-southeast-1.myhuaweicloud.com/huaweiclouddeveloper/cert-manager-webhook-huawei
   tag: latest
   pullPolicy: IfNotPresent
-  privateRegistry:
-    enabled: true
-    dockerRegistrySecret: default-secret
 
 nameOverride: ""
 fullnameOverride: ""


### PR DESCRIPTION
Changes the Helm chart's container image to a public address so everyone can deploy without private registry access.
fixes: #13 