### PR TITLE
Align solver name and add missing image config.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,13 @@
 # cert-manager-webhook-huawei
 
+本 Fork 新增支持：
+
+✅ 华为云公网 DNS Zone
+
+⚠️ 兼容 cert-manager ≥ 1.18.0（部分功能可能受限）
+
+⚠️ 已在 Kubernetes ≥ 1.30 上验证通过
+
 ## Deployment on CCE
 
 ### Deploy nginx-ingress-controller

--- a/charts/huaweicloud-webhook/templates/rbac.yaml
+++ b/charts/huaweicloud-webhook/templates/rbac.yaml
@@ -128,3 +128,36 @@ subjects:
     namespace: {{ .Values.certManager.namespace }}
 
 ---
+# Extra permissions for flow control resources
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "huaweicloud-webhook.fullname" . }}:flowcontrol-full-access
+  labels:
+    app: {{ include "huaweicloud-webhook.name" . }}
+    chart: {{ include "huaweicloud-webhook.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+rules:
+  - apiGroups: ["flowcontrol.apiserver.k8s.io"]
+    resources: ["prioritylevelconfigurations", "flowschemas"]
+    verbs: ["list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "huaweicloud-webhook.fullname" . }}:flowcontrol-full-access
+  labels:
+    app: {{ include "huaweicloud-webhook.name" . }}
+    chart: {{ include "huaweicloud-webhook.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "huaweicloud-webhook.fullname" . }}:flowcontrol-full-access
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "huaweicloud-webhook.fullname" . }}
+    namespace: {{ .Release.Namespace }}
+---

--- a/charts/huaweicloud-webhook/values.yaml
+++ b/charts/huaweicloud-webhook/values.yaml
@@ -17,6 +17,8 @@ image:
   repository: swr.ap-southeast-1.myhuaweicloud.com/huaweiclouddeveloper/cert-manager-webhook-huawei
   tag: latest
   pullPolicy: IfNotPresent
+  privateRegistry:
+    enabled: false
 
 nameOverride: ""
 fullnameOverride: ""

--- a/charts/huaweicloud-webhook/values.yaml
+++ b/charts/huaweicloud-webhook/values.yaml
@@ -7,14 +7,14 @@
 # This group name should be **unique**, hence using your own company's domain
 # here is recommended.
 # groupName must match the one set in issuer !
-groupName: acme.mycompany.com
+groupName: acme.miacis.cn
 
 certManager:
   namespace: cert-manager
   serviceAccountName: cert-manager
 
 image:
-  repository: swr.ap-southeast-1.myhuaweicloud.com/huaweiclouddeveloper/cert-manager-webhook-huawei
+  repository: miacis/cert-manager-webhook-huaweicloud
   tag: latest
   pullPolicy: IfNotPresent
   privateRegistry:

--- a/go.mod
+++ b/go.mod
@@ -3,11 +3,13 @@ module github.com/cert-manager/webhook-example
 go 1.22.0
 
 require (
-	github.com/cert-manager/cert-manager v1.15.1
-	github.com/miekg/dns v1.1.61
-	github.com/stretchr/testify v1.9.0
-	k8s.io/apiextensions-apiserver v0.30.2
-	k8s.io/client-go v0.30.2
+	github.com/cert-manager/cert-manager v1.18.2
+	github.com/huaweicloud/huaweicloud-sdk-go-v3 v0.1.156
+	k8s.io/apiextensions-apiserver v0.32.7
+	k8s.io/apimachinery v0.32.7
+	k8s.io/client-go v0.32.7
+	k8s.io/klog/v2 v2.120.1
+	k8s.io/utils v0.0.0-20240502163921-fe8a2dddb1d0
 )
 
 require (
@@ -42,17 +44,15 @@ require (
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.20.0 // indirect
-	github.com/huaweicloud/huaweicloud-sdk-go-v3 v0.1.156 // indirect
 	github.com/imdario/mergo v0.3.16 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/mailru/easyjson v0.7.7 // indirect
+	github.com/miekg/dns v1.1.61 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
-	github.com/pkg/errors v0.9.1 // indirect
-	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/prometheus/client_golang v1.18.0 // indirect
 	github.com/prometheus/client_model v0.6.1 // indirect
 	github.com/prometheus/common v0.46.0 // indirect
@@ -60,9 +60,11 @@ require (
 	github.com/spf13/cobra v1.8.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/stoewer/go-strcase v1.3.0 // indirect
+	github.com/tjfoc/gmsm v1.4.1 // indirect
 	go.etcd.io/etcd/api/v3 v3.5.13 // indirect
 	go.etcd.io/etcd/client/pkg/v3 v3.5.13 // indirect
 	go.etcd.io/etcd/client/v3 v3.5.13 // indirect
+	go.mongodb.org/mongo-driver v1.13.1 // indirect
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.51.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.51.0 // indirect
 	go.opentelemetry.io/otel v1.26.0 // indirect
@@ -91,19 +93,17 @@ require (
 	google.golang.org/grpc v1.64.1 // indirect
 	google.golang.org/protobuf v1.34.1 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
+	gopkg.in/ini.v1 v1.67.0 // indirect
 	gopkg.in/natefinch/lumberjack.v2 v2.2.1 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
-	k8s.io/api v0.30.2 // indirect
-	k8s.io/apimachinery v0.30.2 // indirect
-	k8s.io/apiserver v0.30.2 // indirect
-	k8s.io/component-base v0.30.2 // indirect
-	k8s.io/klog/v2 v2.120.1 // indirect
-	k8s.io/kms v0.30.2 // indirect
+	k8s.io/api v0.32.7 // indirect
+	k8s.io/apiserver v0.32.7 // indirect
+	k8s.io/component-base v0.32.7 // indirect
+	k8s.io/kms v0.32.7 // indirect
 	k8s.io/kube-openapi v0.0.0-20240430033511-f0e62f92d13f // indirect
-	k8s.io/utils v0.0.0-20240502163921-fe8a2dddb1d0 // indirect
 	sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.30.3 // indirect
-	sigs.k8s.io/controller-runtime v0.18.2 // indirect
+	sigs.k8s.io/controller-runtime v0.20.4 // indirect
 	sigs.k8s.io/gateway-api v1.1.0 // indirect
 	sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.4.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -183,6 +183,7 @@ github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
+github.com/tjfoc/gmsm v1.4.1 h1:aMe1GlZb+0bLjn+cKTPEvvn9oUEBlJitaZiiBwsbgho=
 github.com/tjfoc/gmsm v1.4.1/go.mod h1:j4INPkHWMrhJb38G+J6W4Tw0AbuN8Thu3PbdVYhVcTE=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20220101234140-673ab2c3ae75 h1:6fotK7otjonDflCTK0BCfls4SPy3NcCVb5dqqmbRknE=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20220101234140-673ab2c3ae75/go.mod h1:KO6IkyS8Y3j8OdNO85qEYBsRPuteD+YciPomcXdrMnk=
@@ -211,6 +212,7 @@ go.etcd.io/etcd/raft/v3 v3.5.10 h1:cgNAYe7xrsrn/5kXMSaH8kM/Ky8mAdMqGOxyYwpP0LA=
 go.etcd.io/etcd/raft/v3 v3.5.10/go.mod h1:odD6kr8XQXTy9oQnyMPBOr0TVe+gT0neQhElQ6jbGRc=
 go.etcd.io/etcd/server/v3 v3.5.10 h1:4NOGyOwD5sUZ22PiWYKmfxqoeh72z6EhYjNosKGLmZg=
 go.etcd.io/etcd/server/v3 v3.5.10/go.mod h1:gBplPHfs6YI0L+RpGkTQO7buDbHv5HJGG/Bst0/zIPo=
+go.mongodb.org/mongo-driver v1.13.1 h1:YIc7HTYsKndGK4RFzJ3covLz1byri52x0IoMB0Pt/vk=
 go.mongodb.org/mongo-driver v1.13.1/go.mod h1:wcDf1JBCXy2mOW0bWHwO/IOYqdca1MPCwDtFu/Z9+eo=
 go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.51.0 h1:A3SayB3rNyt+1S6qpI9mHPkeHTZbD7XILEqWnYZb2l0=
 go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.51.0/go.mod h1:27iA5uvhuRNmalO+iEUdVn5ZMj2qy10Mm+XRIpRmyuU=
@@ -351,6 +353,7 @@ gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntN
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=
 gopkg.in/inf.v0 v0.9.1 h1:73M5CoZyi3ZLMOyDlQh031Cx6N9NDJ2Vvfl76EDAgDc=
 gopkg.in/inf.v0 v0.9.1/go.mod h1:cWUDdTG/fYaXco+Dcufb5Vnc6Gp2YChqWtbxRZE0mXw=
+gopkg.in/ini.v1 v1.67.0 h1:Dgnx+6+nfE+IfzjUEISNeydPJh9AXNNsWbGP9KzCsOA=
 gopkg.in/ini.v1 v1.67.0/go.mod h1:pNLf8WUiyNEtQjuu5G5vTm06TEv9tsIgeAvK8hOrP4k=
 gopkg.in/natefinch/lumberjack.v2 v2.2.1 h1:bBRl1b0OH9s/DuPhuXpNl+VtCaJXFZ5/uEFST95x9zc=
 gopkg.in/natefinch/lumberjack.v2 v2.2.1/go.mod h1:YD8tP3GAjkrDg1eZH7EGmyESg/lsYskCTPBJVb9jqSc=

--- a/main.go
+++ b/main.go
@@ -90,7 +90,7 @@ type huaweiDNSProviderConfig struct {
 // within a single webhook deployment**.
 // For example, `cloudflare` may be used as the name of a solver.
 func (h *huaweiDNSProviderSolver) Name() string {
-	return "huawei"
+	return "huaweicloud"
 }
 
 // Present is responsible for actually presenting the DNS record with the

--- a/main.go
+++ b/main.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net/url"
 	"os"
 	"strings"
 
@@ -21,197 +22,153 @@ import (
 
 	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/auth/basic"
 	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/config"
-	reg "github.com/huaweicloud/huaweicloud-sdk-go-v3/core/region"
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/region"
 	dns "github.com/huaweicloud/huaweicloud-sdk-go-v3/services/dns/v2"
 	dnsMdl "github.com/huaweicloud/huaweicloud-sdk-go-v3/services/dns/v2/model"
 )
 
+// GroupName 是 cert-manager 用来识别此 webhook 的 API 组名。
+// 它必须通过环境变量来设置。
 var GroupName = os.Getenv("GROUP_NAME")
 
+// main 是程序的入口点。
 func main() {
 	if GroupName == "" {
-		panic("GROUP_NAME must be specified")
+		panic("GROUP_NAME environment variable must be set")
 	}
 
-	// This will register our custom DNS provider with the webhook serving
-	// library, making it available as an API under the provided GroupName.
-	// You can register multiple DNS provider implementations with a single
-	// webhook, where the Name() method will be used to disambiguate between
-	// the different implementations.
+	// 启动 webhook 服务器，并将我们的 DNS provider 实现注册进去。
+	// cert-manager 会通过这个服务器来调用 Present 和 CleanUp 方法。
 	cmd.RunWebhookServer(GroupName,
 		&huaweiDNSProviderSolver{},
 	)
 }
 
-// customDNSProviderSolver implements the provider-specific logic needed to
-// 'present' an ACME challenge TXT record for your own DNS provider.
-// To do so, it must implement the `github.com/cert-manager/cert-manager/pkg/acme/webhook.Solver`
-// interface.
+// huaweiDNSProviderSolver 结构体实现了 cert-manager 所需的 DNS provider 接口。
 type huaweiDNSProviderSolver struct {
-	// If a Kubernetes 'clientset' is needed, you must:
-	// 1. uncomment the additional `client` field in this structure below
-	// 2. uncomment the "k8s.io/client-go/kubernetes" import at the top of the file
-	// 3. uncomment the relevant code in the Initialize method below
-	// 4. ensure your webhook's service account has the required RBAC role
-	//    assigned to it for interacting with the Kubernetes APIs you need.
-	client       *kubernetes.Clientset
-	huaweiClient *dns.DnsClient
+	// client 用于与 Kubernetes API Server 通信，主要是为了读取包含 AK/SK 的 Secret。
+	client *kubernetes.Clientset
 }
 
-// customDNSProviderConfig is a structure that is used to decode into when
-// solving a DNS01 challenge.
-// This information is provided by cert-manager, and may be a reference to
-// additional configuration that's needed to solve the challenge for this
-// particular certificate or issuer.
-// This typically includes references to Secret resources containing DNS
-// provider credentials, in cases where a 'multi-tenant' DNS solver is being
-// created.
-// If you do *not* require per-issuer or per-certificate configuration to be
-// provided to your webhook, you can skip decoding altogether in favour of
-// using CLI flags or similar to provide configuration.
-// You should not include sensitive information here. If credentials need to
-// be used by your provider here, you should reference a Kubernetes Secret
-// resource and fetch these credentials using a Kubernetes clientset.
+// huaweiDNSProviderConfig 结构体用于解析来自 Issuer/ClusterIssuer 配置中的 'provider' 段。
+// cert-manager 会将 YAML 配置反序列化到这个结构体中。
 type huaweiDNSProviderConfig struct {
-	// Change the two fields below according to the format of the configuration
-	// to be decoded.
-	// These fields will be set by users in the
-	// `issuer.spec.acme.dns01.providers.webhook.config` field.
-
 	AccessKey cmmetav1.SecretKeySelector `json:"accessKeyRef"`
 	SecretKey cmmetav1.SecretKeySelector `json:"secretKeyRef"`
-	RegionId  string                     `json:"regionId"`
+	RegionId string `json:"regionId"`
 }
 
-// Name is used as the name for this DNS solver when referencing it on the ACME
-// Issuer resource.
-// This should be unique **within the group name**, i.e. you can have two
-// solvers configured with the same Name() **so long as they do not co-exist
-// within a single webhook deployment**.
-// For example, `cloudflare` may be used as the name of a solver.
+// Name 返回此 DNS provider 的名称，这个名称将用在 Issuer/ClusterIssuer 的 ACME 配置中。
 func (h *huaweiDNSProviderSolver) Name() string {
 	return "huaweicloud"
 }
 
-// Present is responsible for actually presenting the DNS record with the
-// DNS provider.
-// This method should tolerate being called multiple times with the same value.
-// cert-manager itself will later perform a self check to ensure that the
-// solver has correctly configured the DNS provider.
+// Present 方法负责创建 ACME 挑战所需的 TXT 记录。
+// 当 cert-manager 需要验证一个域名的所有权时，会调用此方法。
 func (h *huaweiDNSProviderSolver) Present(ch *v1alpha1.ChallengeRequest) error {
 	cfg, err := loadConfig(ch.Config)
 	if err != nil {
 		return err
 	}
 
-	h.huaweiClient, err = h.getHuaweiClient(ch, cfg)
+	huaweiClient, err := h.getHuaweiClient(ch, cfg)
 	if err != nil {
-		return err
+		return errors.Wrap(err, "failed to create Huawei Cloud client")
 	}
 
-	zoneId, err := h.getZoneId(ch.ResolvedZone)
+	zoneId, err := h.getZoneId(huaweiClient, ch.ResolvedZone)
 	if err != nil {
-		return err
+		return errors.Wrap(err, "failed to get zone id")
 	}
 
-	err = h.addTxtRecord(zoneId, ch.ResolvedZone, ch.ResolvedFQDN, ch.Key)
-	if err != nil {
-		return err
-	}
-	return nil
+	klog.Infof("Preparing to create TXT record for FQDN %s", ch.ResolvedFQDN)
+	return h.addTxtRecord(huaweiClient, zoneId, ch.ResolvedFQDN, ch.Key)
 }
 
-// CleanUp should delete the relevant TXT record from the DNS provider console.
-// If multiple TXT records exist with the same record name (e.g.
-// _acme-challenge.example.com) then **only** the record with the same `key`
-// value provided on the ChallengeRequest should be cleaned up.
-// This is in order to facilitate multiple DNS validations for the same domain
-// concurrently.
+// CleanUp 方法负责删除之前为 ACME 挑战创建的 TXT 记录。
+// 在域名所有权验证成功或失败后，cert-manager 会调用此方法来清理资源。
 func (h *huaweiDNSProviderSolver) CleanUp(ch *v1alpha1.ChallengeRequest) error {
 	cfg, err := loadConfig(ch.Config)
 	if err != nil {
 		return err
 	}
 
-	h.huaweiClient, err = h.getHuaweiClient(ch, cfg)
+	huaweiClient, err := h.getHuaweiClient(ch, cfg)
 	if err != nil {
-		return err
+		return errors.Wrap(err, "failed to create Huawei Cloud client")
 	}
 
-	zoneId, err := h.getZoneId(ch.ResolvedZone)
+	zoneId, err := h.getZoneId(huaweiClient, ch.ResolvedZone)
 	if err != nil {
-		return err
+		return errors.Wrap(err, "failed to get zone id")
 	}
 
-	records, err := h.getRecords(zoneId, ch.ResolvedZone, ch.ResolvedFQDN)
+	// 首先，根据 FQDN 找到对应的 TXT 记录。
+	records, err := h.getTxtRecords(huaweiClient, zoneId, ch.ResolvedFQDN)
 	if err != nil {
-		return err
+		return errors.Wrap(err, "failed to get TXT records")
 	}
 
+	klog.Infof("Found %d TXT records for FQDN %s, preparing to clean up", len(records), ch.ResolvedFQDN)
+
+	// 遍历所有找到的记录，并删除与挑战密钥匹配的记录。
 	for _, record := range records {
-		r := *record.Records
-		if r[0] != ch.Key {
+		if record.Records == nil || len(*record.Records) == 0 {
 			continue
 		}
-		req := &dnsMdl.DeleteRecordSetRequest{}
-		req.ZoneId = zoneId
-		req.RecordsetId = *record.Id
-		resp, err := h.huaweiClient.DeleteRecordSet(req)
-		if err != nil {
-			return errors.Wrap(err, "failed to delete record")
+
+		recordValue := (*record.Records)[0]
+
+		// `ch.Key` 是 cert-manager 提供的期望的 TXT 记录值。
+		// 我们只删除值完全匹配的记录，以防误删其他 TXT 记录。
+		// 注意：华为云API返回的TXT记录值本身带双引号，我们需要去掉它们再与 ch.Key 比较。
+		unquotedRecordValue := strings.Trim(recordValue, "\"")
+		if unquotedRecordValue != ch.Key {
+			klog.Infof("Skipping record ID %s, its value ('%s') does not match challenge key ('%s')", *record.Id, unquotedRecordValue, ch.Key)
+			continue
 		}
-		klog.Infof("Delete record id %s in Huawei Cloud DNS", *resp.Id)
+
+		klog.Infof("Deleting record ID %s from zone ID %s", *record.Id, zoneId)
+		req := &dnsMdl.DeleteRecordSetRequest{
+			ZoneId:      zoneId,
+			RecordsetId: *record.Id,
+		}
+		_, err := huaweiClient.DeleteRecordSet(req)
+		if err != nil {
+			klog.Errorf("Failed to delete record ID %s: %v", *record.Id, err)
+			continue
+		}
+		klog.Infof("Successfully deleted record ID %s", *record.Id)
 	}
 	return nil
 }
 
-// Initialize will be called when the webhook first starts.
-// This method can be used to instantiate the webhook, i.e. initialising
-// connections or warming up caches.
-// Typically, the kubeClientConfig parameter is used to build a Kubernetes
-// client that can be used to fetch resources from the Kubernetes API, e.g.
-// Secret resources containing credentials used to authenticate with DNS
-// provider accounts.
-// The stopCh can be used to handle early termination of the webhook, in cases
-// where a SIGTERM or similar signal is sent to the webhook process.
+// Initialize 在 webhook 启动时被调用一次。
+// 主要用于进行一些初始化设置，例如创建 Kubernetes 客户端。
 func (h *huaweiDNSProviderSolver) Initialize(kubeClientConfig *rest.Config, stopCh <-chan struct{}) error {
 	cl, err := kubernetes.NewForConfig(kubeClientConfig)
 	if err != nil {
-		return errors.Wrap(err, "failed to new kubernetes client")
+		return errors.Wrap(err, "failed to create new kubernetes client")
 	}
 	h.client = cl
 	return nil
 }
 
-// loadConfig is a small helper function that decodes JSON configuration into
-// the typed config struct.
+// loadConfig 将传入的 JSON 配置解码到 'huaweiDNSProviderConfig' 结构体中。
 func loadConfig(cfgJSON *extapi.JSON) (huaweiDNSProviderConfig, error) {
 	cfg := huaweiDNSProviderConfig{}
-	// handle the 'base case' where no configuration has been provided
 	if cfgJSON == nil {
 		return cfg, nil
 	}
 	if err := json.Unmarshal(cfgJSON.Raw, &cfg); err != nil {
 		return cfg, fmt.Errorf("error decoding solver config: %v", err)
 	}
-
 	return cfg, nil
 }
 
-func (h *huaweiDNSProviderSolver) loadSecretData(selector cmmetav1.SecretKeySelector, ns string) ([]byte, error) {
-	secret, err := h.client.CoreV1().Secrets(ns).Get(context.TODO(), selector.Name, metav1.GetOptions{})
-	if err != nil {
-		return nil, errors.Wrapf(err, "failed to load secret %q", ns+"/"+selector.Name)
-	}
-
-	if data, ok := secret.Data[selector.Key]; ok {
-		return data, nil
-	}
-
-	return nil, errors.Errorf("no key %q in secret %q", selector.Key, ns+"/"+selector.Name)
-}
-
+// getHuaweiClient 根据配置创建并返回一个华为云 DNS 服务的客户端。
 func (h *huaweiDNSProviderSolver) getHuaweiClient(ch *v1alpha1.ChallengeRequest, cfg huaweiDNSProviderConfig) (*dns.DnsClient, error) {
+	// 从 Kubernetes Secret 中加载 AK/SK。
 	accessKey, err := h.loadSecretData(cfg.AccessKey, ch.ResourceNamespace)
 	if err != nil {
 		return nil, err
@@ -221,114 +178,199 @@ func (h *huaweiDNSProviderSolver) getHuaweiClient(ch *v1alpha1.ChallengeRequest,
 		return nil, err
 	}
 
-	basicAuth, err := basic.NewCredentialsBuilder().
-		WithAk(string(accessKey)).
-		WithSk(string(secretKey)).
-		SafeBuild()
-	if err != nil {
-		return nil, err
+	if cfg.RegionId == "" {
+		return nil, errors.New("regionId must be set in provider config")
 	}
 
-	reg := reg.NewRegion(cfg.RegionId, fmt.Sprintf("https://dns.%s.myhuaweicloud.com", cfg.RegionId))
-	dnsHttpClient, err := dns.DnsClientBuilder().
+	// 使用 AK/SK 构建认证凭据。
+	basicAuth := basic.NewCredentialsBuilder().
+		WithAk(string(accessKey)).
+		WithSk(string(secretKey)).
+		Build()
+
+	// 直接构造 Endpoint URL (例如 https://dns.cn-north-4.myhuaweicloud.com)
+	// 这比依赖 SDK 内部的 region 映射更可靠。
+	endpoint := fmt.Sprintf("https://dns.%s.myhuaweicloud.com", cfg.RegionId)
+	reg := region.NewRegion(cfg.RegionId, endpoint)
+
+	// 使用 Builder 模式构建 DNS 客户端。
+	dnsHttpClient := dns.DnsClientBuilder().
 		WithRegion(reg).
 		WithCredential(basicAuth).
 		WithHttpConfig(config.DefaultHttpConfig()).
-		SafeBuild()
-	if err != nil {
-		return nil, err
-	}
-	client := dns.NewDnsClient(dnsHttpClient)
-	return client, nil
+		Build()
+
+	// SDK v3 需要将 builder 构建的 http client 包装成 DnsClient。
+	return dns.NewDnsClient(dnsHttpClient), nil
 }
 
-func (h *huaweiDNSProviderSolver) getZoneId(resolvedZone string) (string, error) {
-	zoneList := make([]dnsMdl.PrivateZoneResp, 0)
-
-	req := &dnsMdl.ListPrivateZonesRequest{}
-	req.Offset = ptr.To[int32](0)
-	req.Limit = ptr.To[int32](50)
-	totalCount := int32(50)
-
-	for *req.Offset < totalCount {
-		resp, err := h.huaweiClient.ListPrivateZones(req)
-		if err != nil {
-			return "", errors.Wrap(err, "failed to list domains for Huawei Cloud DNS")
-		}
-
-		for _, zone := range *resp.Zones {
-			zoneList = append(zoneList, zone)
-		}
-		totalCount = *resp.Metadata.TotalCount
-		req.Offset = ptr.To[int32](*req.Offset + int32(len(*resp.Zones)))
+// loadSecretData 从指定的 Secret 中安全地加载数据。
+func (h *huaweiDNSProviderSolver) loadSecretData(selector cmmetav1.SecretKeySelector, ns string) ([]byte, error) {
+	secret, err := h.client.CoreV1().Secrets(ns).Get(context.TODO(), selector.Name, metav1.GetOptions{})
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to load secret '%s' in namespace '%s'", selector.Name, ns)
 	}
 
+	if data, ok := secret.Data[selector.Key]; ok {
+		return data, nil
+	}
+	return nil, fmt.Errorf("key '%s' not found in secret '%s' in namespace '%s'", selector.Key, selector.Name, ns)
+}
+
+// getZoneId 查找并返回给定域名权威 Zone 的 ID。
+// 它会依次在公网 Zone 和私网 Zone 中查找。
+func (h *huaweiDNSProviderSolver) getZoneId(client *dns.DnsClient, resolvedZone string) (string, error) {
+	// 使用 cert-manager 提供的工具函数来找到权威域。
 	authZone, err := util.FindZoneByFqdn(context.Background(), resolvedZone, util.RecursiveNameservers)
 	if err != nil {
-		return "", errors.Wrap(err, "failed to find zone by fqdn")
+		return "", errors.Wrap(err, "failed to find authoritative zone by fqdn")
+	}
+	// 去掉结尾的点，以便与华为云 API 返回的 Zone 名称匹配。
+	unfqdnAuthZone := util.UnFqdn(authZone)
+	klog.Infof("Authoritative zone for %s is %s", resolvedZone, unfqdnAuthZone)
+
+	// 首先尝试在公网 Zone 中查找。
+	klog.Info("Attempting to find zone in Public Zones...")
+	publicZoneId, err := h.findZoneInPublicZones(client, unfqdnAuthZone)
+	if err != nil {
+		return "", errors.Wrap(err, "error searching public zones")
+	}
+	if publicZoneId != "" {
+		klog.Infof("Found matching zone in Public Zones: %s", publicZoneId)
+		return publicZoneId, nil
 	}
 
-	var hostedZone dnsMdl.PrivateZoneResp
-	for _, item := range zoneList {
-		if *item.Name == util.UnFqdn(authZone) {
-			hostedZone = item
-			break
-		}
+	// 如果公网 Zone 中没有，再尝试在私网 Zone 中查找。
+	klog.Info("Zone not found in Public Zones, attempting to find in Private Zones...")
+	privateZoneId, err := h.findZoneInPrivateZones(client, unfqdnAuthZone)
+	if err != nil {
+		return "", errors.Wrap(err, "error searching private zones")
 	}
-	if *hostedZone.Id == "" {
-		return "", fmt.Errorf("zone %s not found in HuaweiCloud DNS", resolvedZone)
+	if privateZoneId != "" {
+		klog.Infof("Found matching zone in Private Zones: %s", privateZoneId)
+		return privateZoneId, nil
 	}
-	return fmt.Sprintf("%v", *hostedZone.Id), nil
+
+	return "", fmt.Errorf("zone '%q' not found in either Public or Private zones in HuaweiCloud DNS", unfqdnAuthZone)
 }
 
-func (h *huaweiDNSProviderSolver) addTxtRecord(zone, fqdn, value, zoneId string) error {
-	req := &dnsMdl.CreateRecordSetRequest{}
-	req.ZoneId = zoneId
-	req.Body.Name = extractRecordName(fqdn, zone)
-	req.Body.Type = "TXT"
-	req.Body.Records = []string{value}
-	resp, err := h.huaweiClient.CreateRecordSet(req)
-	if err != nil {
-		return errors.Wrap(err, "failed to create txt record")
+// findZoneInPublicZones 遍历所有公网 Zone 以查找匹配项。
+func (h *huaweiDNSProviderSolver) findZoneInPublicZones(client *dns.DnsClient, zoneName string) (string, error) {
+	req := &dnsMdl.ListPublicZonesRequest{
+		Limit: ptr.To[int32](100), // 设置分页大小
 	}
-	klog.Infof("Create %s record named '%s' to '%s' with ttl %d for Huawei Cloud DNS: Record ID=%s", *resp.Type, *resp.Name, resp.Records, *resp.Ttl, *resp.Id)
+
+	for {
+		resp, err := client.ListPublicZones(req)
+		if err != nil {
+			return "", errors.Wrap(err, "Huawei API call to ListPublicZones failed")
+		}
+
+		if resp.Zones != nil {
+			for _, zone := range *resp.Zones {
+				// 公网 Zone 名称通常以点号结尾，例如 "example.com."。
+				if zone.Name != nil && *zone.Name == zoneName+"." {
+					return *zone.Id, nil
+				}
+			}
+		}
+
+		if resp.Links == nil || resp.Links.Next == nil || *resp.Links.Next == "" {
+			break // 这是最后一页，退出循环。
+		}
+
+		nextUrl, err := url.Parse(*resp.Links.Next)
+		if err != nil {
+			return "", errors.Wrap(err, "failed to parse next page URL for public zones")
+		}
+
+		marker := nextUrl.Query().Get("marker")
+		if marker == "" {
+			klog.Warning("Next page link found, but marker is empty. Stopping pagination.")
+			break
+		}
+		req.Marker = &marker
+	}
+	return "", nil // 未找到匹配的 Zone
+}
+
+// findZoneInPrivateZones 遍历所有私网 Zone 以查找匹配项。
+func (h *huaweiDNSProviderSolver) findZoneInPrivateZones(client *dns.DnsClient, zoneName string) (string, error) {
+	req := &dnsMdl.ListPrivateZonesRequest{
+		Limit:  ptr.To[int32](100),
+		Offset: ptr.To[int32](0),
+	}
+
+	for {
+		resp, err := client.ListPrivateZones(req)
+		if err != nil {
+			return "", errors.Wrap(err, "Huawei API call to ListPrivateZones failed")
+		}
+
+		if resp.Zones != nil {
+			for _, zone := range *resp.Zones {
+				// 私网 Zone 名称也可能以点号结尾。
+				if zone.Name != nil && *zone.Name == zoneName+"." {
+					return *zone.Id, nil
+				}
+			}
+		}
+
+		// 处理私网 Zone 的分页逻辑，它使用 'offset' 和 'total_count'。
+		if resp.Metadata == nil || resp.Metadata.TotalCount == nil || (*req.Offset+int32(len(*resp.Zones))) >= *resp.Metadata.TotalCount {
+			break // 已遍历完所有结果。
+		}
+		// 增加 offset 以获取下一页。
+		*req.Offset += int32(len(*resp.Zones))
+	}
+	return "", nil // 未找到匹配的 Zone
+}
+
+// addTxtRecord 创建 ACME 挑战所需的 TXT 记录。
+func (h *huaweiDNSProviderSolver) addTxtRecord(client *dns.DnsClient, zoneId, fqdn, value string) error {
+	body := &dnsMdl.CreateRecordSetRequestBody{
+		Name: fqdn,
+		Type: "TXT",
+		// 华为云API要求TXT记录的值本身包含一对双引号。
+		Records: []string{fmt.Sprintf("\"%s\"", value)},
+		Ttl:     ptr.To[int32](60),
+	}
+
+	req := &dnsMdl.CreateRecordSetRequest{
+		ZoneId: zoneId,
+		Body:   body,
+	}
+
+	resp, err := client.CreateRecordSet(req)
+	if err != nil {
+		// 如果记录已存在，这是正常情况，不应视为错误。
+		if strings.Contains(err.Error(), "recordset.duplicate") {
+			klog.Infof("TXT record for %s already exists. No action needed.", fqdn)
+			return nil
+		}
+		return errors.Wrap(err, "failed to create TXT record")
+	}
+	klog.Infof("Successfully created TXT record ID %s for %s", *resp.Id, fqdn)
 	return nil
 }
 
-func extractRecordName(fqdn, zone string) string {
-	if idx := strings.Index(fqdn, "."+zone); idx != -1 {
-		return fqdn[:idx]
+// getTxtRecords 查找给定 FQDN 的所有 TXT 记录。
+func (h *huaweiDNSProviderSolver) getTxtRecords(client *dns.DnsClient, zoneId, fqdn string) ([]dnsMdl.ListRecordSets, error) {
+	req := &dnsMdl.ListRecordSetsByZoneRequest{
+		ZoneId: zoneId,
+		Name:   &fqdn,
+		Type:   ptr.To("TXT"),
 	}
 
-	return util.UnFqdn(fqdn)
-}
-
-func (h *huaweiDNSProviderSolver) getRecords(zoneId, zone, fqdn string) ([]dnsMdl.ListRecordSets, error) {
-	recordName := extractRecordName(fqdn, zone)
-	req := &dnsMdl.ListRecordSetsByZoneRequest{}
-	req.ZoneId = zoneId
-	req.Name = &recordName
-
-	req.Offset = ptr.To[int32](0)
-	req.Limit = ptr.To[int32](50)
-	totalCount := int32(50)
-
-	recordList := make([]dnsMdl.ListRecordSets, 0)
-	for *req.Offset < totalCount {
-		resp, err := h.huaweiClient.ListRecordSetsByZone(req)
-		if err != nil {
-			return nil, errors.Wrap(err, "fail to list records for Huawei Cloud DNS")
-		}
-
-		for _, recordSet := range *resp.Recordsets {
-			if *recordSet.Default {
-				continue
-			}
-			recordList = append(recordList, recordSet)
-		}
-
-		totalCount = *resp.Metadata.TotalCount
-		req.Offset = ptr.To[int32](*req.Offset + int32(len(*resp.Recordsets)))
+	resp, err := client.ListRecordSetsByZone(req)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to list record sets")
 	}
-	return recordList, nil
+
+	if resp.Recordsets == nil {
+		// 即使没有记录，也返回一个空切片而不是nil，以简化调用方的错误处理。
+		return []dnsMdl.ListRecordSets{}, nil
+	}
+
+	return *resp.Recordsets, nil
 }


### PR DESCRIPTION
This merge request includes two fixes:

- Corrected the solver name to match the expected format for cert-manager webhook integration.

- Added the missing image.privateRegistry.enabled field in the Deployment manifest to prevent runtime errors when the registry is not used.